### PR TITLE
Features/fix db sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+*.sw?
 *.pyc
 
 dist

--- a/leaderboard/db.py
+++ b/leaderboard/db.py
@@ -1,0 +1,41 @@
+from sqlalchemy import (
+    create_engine
+)
+
+from sqlalchemy.orm import sessionmaker, scoped_session
+
+
+def conn_str():
+    conn_tmpl = 'postgresql+pg8000://%(user)s:%(password)s@localhost/%(database)s'
+    jdata = {"user": "mozstumbler",
+             "password": "stumbler",
+             "database": "leaderboard"}
+    return conn_tmpl % jdata
+
+
+def get_engine(uri):
+    options = {
+        'pool_recycle': 3600,
+        'pool_size': 10,
+        'pool_timeout': 10,
+        'max_overflow': 10,
+        'echo': False,
+    }
+    options['connect_args'] = {'charset': 'utf8'}
+    options['execution_options'] = {'autocommit': False}
+    return create_engine(uri, **options)
+
+session_factory = scoped_session(sessionmaker(expire_on_commit=False,
+                                      autocommit=True))
+
+
+
+def init_sessions():
+    # Setup the global database engine and session manager
+    engine = get_engine(conn_str())
+    session_factory.configure(bind=engine)
+
+    # TODO: this is terrible - fix this
+    from leaderboard.models.db import get_db
+
+    return get_db()

--- a/leaderboard/db.py
+++ b/leaderboard/db.py
@@ -52,7 +52,7 @@ def get_engine(uri):
         'echo': False,
     }
     options['connect_args'] = {'charset': 'utf8'}
-    options['execution_options'] = {'autocommit': False}
+    options['execution_options'] = {'autocommit': True}
     return create_engine(uri, **options)
 
 session_factory = scoped_session(sessionmaker(expire_on_commit=False,

--- a/leaderboard/geo_util/coord_utils.py
+++ b/leaderboard/geo_util/coord_utils.py
@@ -1,10 +1,9 @@
 import math
-from sqlalchemy.engine import ResultProxy
 import coord_sys as cs
 
 # Code from here, http://wiki.openstreetmap.org/wiki/Mercator
 # spherical world mercator (not elliptical)
-from leaderboard.models.db import get_db
+from leaderboard.db import session_factory
 
 earth_radius = 6378137.000
 
@@ -16,7 +15,8 @@ def lon2x_m(lon):
 
 def db_get_easting_northing(lon, lat):
     q = "SELECT ST_AsText(%s)" % db_coord_transform(lon, lat, cs.WGS84_LATLON_CODE, cs.WEB_MERCATOR_CODE)
-    result = get_db().get_session().execute(q).fetchone()[0]
+    session = session_factory()
+    result = session.execute(q).fetchone()[0]
     easting, northing = result.replace('POINT(', '').replace(')', '').split()
     return round(float(easting)), round(float(northing))
 

--- a/leaderboard/middleware.py
+++ b/leaderboard/middleware.py
@@ -1,0 +1,22 @@
+import sqlalchemy.orm.scoping as scoping
+
+
+class SQLAlchemySessionManager(object):
+    def __init__(self, session_factory, auto_commit=False):
+        self._session_factory = session_factory
+        self._scoped = isinstance(session_factory, scoping.ScopedSession)
+        self._auto_commit = auto_commit
+
+    def process_request(self, req, resp, params):
+        req.context['session'] = self._session_factory()
+
+    def process_response(self, req, resp):
+        session = req.context['session']
+
+        if self._auto_commit:
+            session.commit()
+
+        if self._scoped:
+            session.remove()
+        else:
+            session.close()

--- a/leaderboard/models/country_bounds.py
+++ b/leaderboard/models/country_bounds.py
@@ -1,6 +1,7 @@
 from geoalchemy2 import Geometry, func
 from sqlalchemy import Column, Integer, String
 from leaderboard.geo_util import coord_sys as cs
+from leaderboard.db import session_factory
 from leaderboard.models.db import get_db
 
 creation_command = 'ogr2ogr -f PostgreSQL PG:"port=5432" *.geo.json -nln country_bounds'
@@ -21,54 +22,54 @@ class CountryBounds(get_db().Base):
         import os
         pwd = os.path.dirname(os.path.abspath(__file__))
         infile = "%s/../fixtures/world.geo.json" % pwd
-        print infile
         drv = ogr.GetDriverByName('GeoJSON')
         assert drv
         ds = drv.Open(infile)
-        print ds
         layer = ds.GetLayer(0)
-        db = get_db()
         srs = ogr.osr.SpatialReference()
         srs.ImportFromEPSG(4326)
-        for feature in layer:
-            id = feature.GetFID()
-            name = feature.GetField(0)
-            geo = feature.GetGeometryRef()
-            wkb = 'SRID=%d;%s' % (CountryBounds.coord_sys(), geo.ExportToWkt())
-            country = CountryBounds(ogc_fid=id, wkb_geometry=wkb, name=name)
-            db.session.add(country)
-
-        db.session.commit()
+        session = session_factory()
+        with session.begin(subtransactions=True):
+            for feature in layer:
+                id = feature.GetFID()
+                name = feature.GetField(0)
+                geo = feature.GetGeometryRef()
+                wkb = 'SRID=%d;%s' % (CountryBounds.coord_sys(), geo.ExportToWkt())
+                country = CountryBounds(ogc_fid=id, wkb_geometry=wkb, name=name)
+                session.add(country)
 
     @staticmethod
     def set_country_for_tile(tile, use_intersect=False, use_nearby=False):
         from tile import Tile
         assert isinstance(tile, Tile)
         geo = tile.geo_as_wgs84()
-        result = get_db().session.query(CountryBounds).filter(
-            CountryBounds.wkb_geometry.ST_Contains(func.ST_Centroid(geo)))
-        c = result.first()
 
-        if not c or use_intersect:
-            result = get_db().session.query(CountryBounds).filter(CountryBounds.wkb_geometry.ST_Intersects(geo))
+        session = session_factory()
+        with session.begin(subtransactions=True):
+            result = session.query(CountryBounds).filter(
+                CountryBounds.wkb_geometry.ST_Contains(func.ST_Centroid(geo)))
             c = result.first()
 
-        if not c or use_nearby:
-            # https://github.com/geoalchemy/geoalchemy2/issues/94 broken <->
-            # also doesn't work SELECT ogc_fid FROM country_bounds ORDER BY wkb_geometry <-> ST_Centroid('%s') LIMIT 1
-            result = get_db().session.query(CountryBounds)
-            nearby = '''
-                WITH index_query AS (
-                  SELECT ST_Distance(wkb_geometry, '%s') as d, name, ogc_fid
-                    FROM country_bounds
-                  ORDER BY wkb_geometry <-> '%s' LIMIT 10)
-                  SELECT ogc_fid
-                    FROM index_query
-                  ORDER BY d limit 1
-                ''' % (geo, geo)
-            r = get_db().engine.execute(nearby)
-            c_id = r.fetchone()[0]
-            c = get_db().session.query(CountryBounds).filter_by(ogc_fid=c_id).first()
+            if not c or use_intersect:
+                result = session.query(CountryBounds).filter(\
+                                CountryBounds.wkb_geometry.ST_Intersects(geo))
+                c = result.first()
 
-        tile.country = c
-        get_db().session.commit()
+            if not c or use_nearby:
+                # https://github.com/geoalchemy/geoalchemy2/issues/94 broken <->
+                # also doesn't work SELECT ogc_fid FROM country_bounds ORDER BY wkb_geometry <-> ST_Centroid('%s') LIMIT 1
+                result = session.query(CountryBounds)
+                nearby = '''
+                    WITH index_query AS (
+                      SELECT ST_Distance(wkb_geometry, '%s') as d, name, ogc_fid
+                        FROM country_bounds
+                      ORDER BY wkb_geometry <-> '%s' LIMIT 10)
+                      SELECT ogc_fid
+                        FROM index_query
+                      ORDER BY d limit 1
+                    ''' % (geo, geo)
+                r = session.execute(nearby)
+                c_id = r.fetchone()[0]
+                c = session.query(CountryBounds).filter_by(ogc_fid=c_id).first()
+
+            tile.country = c

--- a/leaderboard/route_endpoints/get_leaders.py
+++ b/leaderboard/route_endpoints/get_leaders.py
@@ -1,17 +1,20 @@
 from decimal import Decimal
 from geoalchemy2 import func
 from leaderboard.models import calendar_factory, db, user, tile, country_bounds
+from leaderboard.db import session_factory
 from sqlalchemy import desc
+
 
 def get_leaders_for_country(country_id):
     Week = calendar_factory.get_current_week_table_class()
-    q = db.get_db().get_session().query(user.User,
-                                        func.sum(Week.observation_count).label('obs_sum')).\
-        filter(tile.Tile.country_id == country_id).\
-        filter(Week.user_id == user.User.id).\
-        filter(Week.tile_id == tile.Tile.id).\
-        group_by(user.User.id).\
-        order_by(desc('obs_sum'))
+    session = session_factory()
+    q = session.query(user.User,
+                      func.sum(Week.observation_count).label('obs_sum')).\
+                      filter(tile.Tile.country_id == country_id).\
+                      filter(Week.user_id == user.User.id).\
+                      filter(Week.tile_id == tile.Tile.id).\
+                      group_by(user.User.id).\
+                      order_by(desc('obs_sum'))
     result = q.all()
     if result:
         assert isinstance(result[0][0], user.User)
@@ -21,7 +24,7 @@ def get_leaders_for_country(country_id):
     for row in result:
         rows.append({'name': row[0].nickname, 'observations': row[1]})
 
-    country_name = db.get_db().get_session().query(country_bounds.CountryBounds.name).\
+    country_name = session.query(country_bounds.CountryBounds.name).\
         filter_by(ogc_fid=country_id).first()
 
     return {'country_name': country_name, 'leaders': rows}

--- a/leaderboard/route_endpoints/submit_user_observations.py
+++ b/leaderboard/route_endpoints/submit_user_observations.py
@@ -1,5 +1,5 @@
 import json
-from leaderboard.models.db import get_db
+from leaderboard.db import session_factory
 from leaderboard.models.tile import Tile
 from leaderboard.models.user import User
 from leaderboard.models.calendar_factory import insert_or_update_week
@@ -8,24 +8,25 @@ key_observations = 'observations'
 
 
 def add_stumbles_for_user(email, login_token, query_json):
-    user = get_db().session.query(User).filter_by(email=email).first()
-    if not user:
-        return False
+    session = session_factory()
+    with session.begin(subtransactions=True):
+        user = session.query(User).filter_by(email=email).first()
 
-    if not user.bearer_token or user.bearer_token != login_token:
-        return False
+        if not user:
+            return False
 
-    json_object = json.loads(query_json)
-    for row in json_object:
-        tile_coord = row[key_tile_easting_northing]
-        east, north = tile_coord.split(",")
-        tile = Tile.get_tile_mercator(int(east), int(north))
-        week_per_tile = insert_or_update_week(user, tile)
-        obs = row[key_observations]
-        if not week_per_tile.observation_count:
-            week_per_tile.observation_count = 0
-        week_per_tile.observation_count += obs
+        if not user.bearer_token or user.bearer_token != login_token:
+            return False
 
-    get_db().commit()
+        json_object = json.loads(query_json)
+        for row in json_object:
+            tile_coord = row[key_tile_easting_northing]
+            east, north = tile_coord.split(",")
+            tile = Tile.get_tile_mercator(int(east), int(north))
+            week_per_tile = insert_or_update_week(user, tile)
+            obs = row[key_observations]
+            if not week_per_tile.observation_count:
+                week_per_tile.observation_count = 0
+            week_per_tile.observation_count += obs
 
     return True

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,23 @@
+from leaderboard.db import init_sessions, session_factory
+
+
+class BaseTest(object):
+    """
+    This baseclass should be use for testcases to ensure that tables
+    are all setup and a session is ready for use.
+
+    The database is reset by rolling back transactions in the
+    teardown.
+
+    Any subclasses that override the teardown must call
+    BaseTest.teardown.
+    """
+    def setup(self):
+        if not hasattr(self, 'db'):
+            self.db = init_sessions()
+            self.db.drop_all()
+            self.db.create_all()
+        self.session = session_factory()
+
+    def teardown(self):
+        self.session.rollback()

--- a/tests/test_get_leaders.py
+++ b/tests/test_get_leaders.py
@@ -1,22 +1,15 @@
-from leaderboard.models.db import get_db
-from leaderboard.route_endpoints import get_leaders
 from leaderboard.route_endpoints.get_leaders import get_leaders_for_country
 
 import test_submit
 
+from test_base import BaseTest
 
-class TestLeaders(object):
-    def setup(self):
-        get_db().drop_all()
-        get_db().create_all()
 
-    def teardown(self):
-        get_db().drop_all()
+class TestLeaders(BaseTest):
 
     def test_leaders(self):
         user = test_submit.create_one_user()
         test_submit.submit_helper(test_submit.canada_observations_json, user)
-
         json = '''
             [
                 { "tile_easting_northing":"100,-700", "observations":200 },


### PR DESCRIPTION
This should fix all of the problems with transactions. 

I still want to remove the get_db().Base and get_db().drop_all and get_db().create_all methods, but that can be done in a separate PR.

Notes: 

Transactions are now using scoped transactions - that basically means transaction per thread of control. Any subsequent call to session_factory() will return the same session.

If you're hellbent on creating a new session, you *must* specify `session.begin(subtransactions=True)` on new subtransaction.

There is now middleware to ensure that a transaction is started on request start and commited when the response is sent out.

Tests now have a base class to setup the same kind of transaction layer.